### PR TITLE
Modernise CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,10 @@ SET(HEADERS
   dblsqd/feed.h
 )
 
-FIND_PACKAGE(Qt5Core REQUIRED)
-FIND_PACKAGE(Qt5Network REQUIRED)
-FIND_PACKAGE(Qt5Widgets REQUIRED)
+FIND_PACKAGE(Qt5 REQUIRED
+	COMPONENTS Core
+		   Network
+		   Widgets)
 
 # Qt 5.7 or greater require C++11 standard. Set this requirement conditionally to lower requirements where possible
 IF (Qt5Core_VERSION VERSION_EQUAL 5.7 OR Qt5Core_VERSION VERSION_GREATER 5.7)
@@ -38,33 +39,21 @@ ENDIF()
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
-ADD_DEFINITIONS(
-  ${Qt5Core_DEFINITIONS}
-  ${Qt5Network_DEFINTIONS}
-  ${Qt5Widgets_DEFINTIONS}
-)
-
-
-SET(CMAKE_INCLUDE_CURRENT_DIR ON)
-INCLUDE_DIRECTORIES(
-  ${Qt5Core_INCLUDE_DIRS}
-  ${Qt5Network_INCLUDE_DIRS}
-  ${Qt5Widgets_INCLUDE_DIRS}
-)
-
 ADD_LIBRARY(dblsqd STATIC
   ${SOURCES} ${HEADERS}
 )
 
+TARGET_LINK_LIBRARIES(dblsqd
+	Qt5::Core
+	Qt5::Network
+	Qt5::Widgets)
+
 # publish the include directories to allow dependent projects to find the needed headers
 TARGET_INCLUDE_DIRECTORIES(dblsqd PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${Qt5Core_INCLUDE_DIRS}
-  ${Qt5Network_INCLUDE_DIRS}
-  ${Qt5Widgets_INCLUDE_DIRS}
 # the includes below are needed to find generated uic headers
 # see https://gitlab.kitware.com/cmake/cmake/issues/16925
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}/dblsqd_autogen/include
   ${CMAKE_CURRENT_BINARY_DIR}/dblsqd_autogen/include_$<CONFIG>
+  ${CMAKE_CURRENT_SOURCE_DIR}
 )


### PR DESCRIPTION
This improves both the syntax of finding Qt5 components as well
as linking/importing all of its properties.