### PR TITLE
Add compatibility for building against Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
+OPTION(BUILD_WITH_QT5 "Whether to build with Qt5 or Qt6." ON)
+
 IF(POLICY CMP0020)
   CMAKE_POLICY(SET CMP0020 NEW)
 ENDIF()
@@ -20,19 +22,27 @@ SET(HEADERS
   dblsqd/feed.h
 )
 
-FIND_PACKAGE(Qt5 REQUIRED
-	COMPONENTS Core
-		   Network
-		   Widgets)
-
-# Qt 5.7 or greater require C++11 standard. Set this requirement conditionally to lower requirements where possible
-IF (Qt5Core_VERSION VERSION_EQUAL 5.7 OR Qt5Core_VERSION VERSION_GREATER 5.7)
-  set(CMAKE_CXX_STANDARD 11)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+IF(BUILD_WITH_QT5)
+  FIND_PACKAGE(Qt5 REQUIRED
+    COMPONENTS Core
+    Network
+	Widgets)
+	SET(QT_LIBS Qt5::Core Qt5::Network Qt5::Widgets)
+ELSE()
+  FIND_PACKAGE(Qt6 REQUIRED
+    COMPONENTS Core
+	Network
+	Widgets)
+  SET(QT_LIBS Qt6::Core Qt6::Network Qt6::Widgets)
 ENDIF()
 
-IF(Qt5_POSITION_INDEPENDENT_CODE)
-  SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+# Qt 5.7 or greater require C++11 standard. Set this requirement conditionally to lower requirements where possible
+IF(NOT BUILD_WITH_QT5)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ELSEIF(Qt5Core_VERSION VERSION_EQUAL 5.7 OR Qt5Core_VERSION VERSION_GREATER 5.7)
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 ENDIF()
 
 # automatically use moc and uic when needed
@@ -44,9 +54,7 @@ ADD_LIBRARY(dblsqd STATIC
 )
 
 TARGET_LINK_LIBRARIES(dblsqd
-	Qt5::Core
-	Qt5::Network
-	Qt5::Widgets)
+	${QT_LIBS})
 
 # publish the include directories to allow dependent projects to find the needed headers
 TARGET_INCLUDE_DIRECTORIES(dblsqd PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,8 @@ ELSE()
   SET(QT_LIBS Qt6::Core Qt6::Network Qt6::Widgets)
 ENDIF()
 
-# Qt 5.7 or greater require C++11 standard. Set this requirement conditionally to lower requirements where possible
+# Qt 5.7 or greater require C++11 standard. Qt6 or greater require C++17 standard.
+# Set these requirements conditionally to lower requirements where possible
 IF(NOT BUILD_WITH_QT5)
   set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/dblsqd-sdk-qt.pro
+++ b/dblsqd-sdk-qt.pro
@@ -2,7 +2,7 @@ TEMPLATE = lib
 
 INCLUDEPATH += $$PWD
 
-QT += network widgets
+QT += core network widgets
 
 CONFIG += staticlib
 

--- a/dblsqd-sdk-qt.pro
+++ b/dblsqd-sdk-qt.pro
@@ -1,0 +1,22 @@
+TEMPLATE = lib
+
+INCLUDEPATH += $$PWD
+
+QT += network widgets
+
+CONFIG += staticlib
+
+SOURCES += \
+    $$PWD/dblsqd/release.cpp \
+    $$PWD/dblsqd/semver.cpp \
+    $$PWD/dblsqd/update_dialog.cpp \
+    $$PWD/dblsqd/feed.cpp
+
+HEADERS  += \
+    $$PWD/dblsqd/release.h \
+    $$PWD/dblsqd/semver.h \
+    $$PWD/dblsqd/update_dialog.h \
+    $$PWD/dblsqd/feed.h
+
+FORMS    += \
+    $$PWD/dblsqd/update_dialog.ui

--- a/dblsqd/feed.cpp
+++ b/dblsqd/feed.cpp
@@ -256,7 +256,7 @@ void Feed::handleDownloadProgress(qint64 bytesReceived, qint64 bytesTotal) {
 void Feed::handleDownloadReadyRead() {
     if (downloadFile == NULL) {
         QString fileName = downloadReply->url().fileName();
-        int extensionPos = fileName.indexOf(QRegExp("(?:\\.tar)?\\.[a-zA-Z0-9]+$"));
+        int extensionPos = fileName.indexOf(QRegularExpression("(?:\\.tar)?\\.[a-zA-Z0-9]+$"));
         if (extensionPos > -1) {
             fileName.insert(extensionPos, "-XXXXXX");
         }

--- a/dblsqd/semver.cpp
+++ b/dblsqd/semver.cpp
@@ -13,13 +13,14 @@ namespace  dblsqd {
  */
 SemVer::SemVer(QString version) : original(version), valid(false)
 {
-    QRegExp rx(getRegExp());
-    if (rx.indexIn(version) > -1) {
-        this->major = rx.cap(1).toInt();
-        this->minor = rx.cap(2).toInt();
-        this->patch = rx.cap(3).toInt();
-        this->prerelease = rx.cap(4);
-        this->build = rx.cap(5);
+    QRegularExpression rx(getRegExp());
+    QRegularExpressionMatch match = rx.match(version);
+    if (match.hasMatch()) {
+        this->major = match.captured(1).toInt();
+        this->minor = match.captured(2).toInt();
+        this->patch = match.captured(3).toInt();
+        this->prerelease = match.captured(4);
+        this->build = match.captured(5);
         this->valid = true;
     } else {
         this->major = 0;

--- a/dblsqd/semver.h
+++ b/dblsqd/semver.h
@@ -2,7 +2,7 @@
 #define DBLSQD_SEMVER_H
 
 #include <QObject>
-#include <QRegExp>
+#include <QRegularExpression>
 
 namespace  dblsqd {
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Added option in CMakeLists.txt to build against Qt6
- Added .pro file for easier testing og standalone build
- Migrated `QRegExp` to `QRegularExpression` since `QString.indexOf` only supports `QRegularExpression` in Qt6

#### Motivation for adding 

Needed for supporting Qt6 build of Mudlet. 

#### Other info (issues closed, discussion etc)

Part of https://github.com/Mudlet/Mudlet/issues/5623
